### PR TITLE
Prevent selenium server from hanging on stderr.write

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var selenium;
 
 function startSelenium(done) {
 
-    selenium = seleniumStandalone({ stdio: ['ignore', 'pipe', 'pipe'] }, ['-Dphantomjs.binary.path=' + phantomjsFile + '']);
+    selenium = seleniumStandalone({ stdio: ['ignore', 'pipe', 'ignore'] }, ['-Dphantomjs.binary.path=' + phantomjsFile + '']);
 
     var hasRun = false;
     selenium.stdout.on('data', function (data) {


### PR DESCRIPTION
PR make sure selenium server does not hang on stderr.write. 
In case you haven't stumbled upon this before (though I'm sure you have) - [here is an explanation](https://github.com/joyent/node/issues/6764#issuecomment-31364997).
